### PR TITLE
Fixed plugin use in version 2

### DIFF
--- a/gamejolt_api_v2/gjapi_plugin.gd
+++ b/gamejolt_api_v2/gjapi_plugin.gd
@@ -5,7 +5,7 @@ extends EditorPlugin
 func _enter_tree():
 	# When this plugin node enters tree, add the custom type
 
-	add_custom_type("GameJoltAPI", "HTTPRequest", preload("res://addons/gamejolt_api/main.gd"), preload("res://addons/gamejolt_api/gj_icon.png"))
+	add_custom_type("GameJoltAPI", "HTTPRequest", preload("res://addons/gamejolt_api_v2/main.gd"), preload("res://addons/gamejolt_api_v2/gj_icon.png"))
 
 func _exit_tree():
 	# When the plugin node exits the tree, remove the custom type


### PR DESCRIPTION
Version 2 of the plugin fails to work in Godot because the path name is incorrect.  Just updated the paths to work correctly.